### PR TITLE
Cart rule bug: exclude discounted products on CartRule with a selection of product

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1171,8 +1171,8 @@ class CartRuleCore extends ObjectModel
                 $selected_products = $this->checkProductRestrictionsFromCart($context->cart, true);
                 if (is_array($selected_products)) {
                     foreach ($package_products as $product) {
-                        if (in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
-                            || in_array($product['id_product'].'-0', $selected_products)
+                        if ((in_array($product['id_product'].'-'.$product['id_product_attribute'], $selected_products)
+                            || in_array($product['id_product'].'-0', $selected_products))
                             && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                             $price = $product['price'];
                             if ($use_tax) {

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -53,7 +53,7 @@ class GetFileControllerCore extends FrontController
             }
         } else {
             if (!($key = Tools::getValue('key'))) {
-                if(!($key = $this->context->cookie->file_key)){
+                if (!($key = $this->context->cookie->file_key)){
                     $this->displayCustomError('Invalid key.');
                 }
             }
@@ -70,7 +70,7 @@ class GetFileControllerCore extends FrontController
                 if ($order->secure_key != Tools::getValue('secure_key')) {
                     $this->displayCustomError('Invalid key.');
                 }
-                if(!in_array(1, $this->context->customer->getGroups()) || !in_array(2, $this->context->customer->getGroups())){
+                if (!in_array(1, $this->context->customer->getGroups()) || !in_array(2, $this->context->customer->getGroups())){
                     $this->context->cookie->file_key = $key;
                     Tools::redirect('index.php?controller=authentication&back=get-file.php');
                 }

--- a/controllers/front/GetFileController.php
+++ b/controllers/front/GetFileController.php
@@ -53,12 +53,15 @@ class GetFileControllerCore extends FrontController
             }
         } else {
             if (!($key = Tools::getValue('key'))) {
-                $this->displayCustomError('Invalid key.');
+                if(!($key = $this->context->cookie->file_key)){
+                    $this->displayCustomError('Invalid key.');
+                }
             }
 
             Tools::setCookieLanguage();
             if (!$this->context->customer->isLogged() && !Tools::getValue('secure_key') && !Tools::getValue('id_order')) {
-                Tools::redirect('index.php?controller=authentication&back=get-file.php&key='.$key);
+                $this->context->cookie->file_key = $key;
+                Tools::redirect('index.php?controller=authentication&back=get-file.php');
             } elseif (!$this->context->customer->isLogged() && Tools::getValue('secure_key') && Tools::getValue('id_order')) {
                 $order = new Order((int)Tools::getValue('id_order'));
                 if (!Validate::isLoadedObject($order)) {
@@ -66,6 +69,10 @@ class GetFileControllerCore extends FrontController
                 }
                 if ($order->secure_key != Tools::getValue('secure_key')) {
                     $this->displayCustomError('Invalid key.');
+                }
+                if(!in_array(1, $this->context->customer->getGroups()) || !in_array(2, $this->context->customer->getGroups())){
+                    $this->context->cookie->file_key = $key;
+                    Tools::redirect('index.php?controller=authentication&back=get-file.php');
                 }
             }
 


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x 
| Description?  | The cart rules with selection of products and which excludes products with reduction allows products with reduction.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | #14407
| How to test?  | Create a cart rule (%) with a selection of products of which one or more already have a reduction and select exclude the products in promotion.
![Panier](https://user-images.githubusercontent.com/20644112/64962334-84bab280-d897-11e9-8373-9d9ca97f4842.png)
